### PR TITLE
Make curl-cffi optional on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,7 +22,6 @@ requirements:
   run:
     - protobuf >=3.19.0
     - websockets >=13.0
-    - curl-cffi >=0.15
     - platformdirs >=2.0.0
     - python >={{ python_min }}
     - pandas >=1.3.0
@@ -36,6 +35,8 @@ requirements:
     - peewee >=3.16.2
     - beautifulsoup4 >=4.11.1
     - html5lib >=1.1
+  run_constrained:
+    - curl-cffi >=0.15
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As a hard run dependency, curl-cffi blocked Windows entirely — conda-forge has no Windows build of curl-cffi — causing the solver to pin Windows users to yfinance 0.2.57.

Modification: curl-cffi was moved to run_constrained because it's optional since yfinance 1.4.0 (falls back to requests). 

See the try/except block: [yfinance/_http.py](https://github.com/ranaroussi/yfinance/blob/main/yfinance/_http.py#L21-L33)

This was introduced in release 1.4.0: (https://github.com/ranaroussi/yfinance/releases/tag/1.4.0)

 

